### PR TITLE
Make App Versa 2 & Versa Lite Compatible 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Train yourself to run at your optimal cadence with Cadence Coach! Running at you
 Remember not to increase your cadence too quickly to avoid injury.
 
 ### Version
-v1.2.0
+v1.3.0
 
 ### Development
 Want to contribute? Great! Fork and submit a pull request!

--- a/app/index.js
+++ b/app/index.js
@@ -2,10 +2,17 @@ import document from "document";
 import { vibration } from "haptics";
 import { today } from "user-activity";
 import { display } from "display";
+import { me as device } from "device";
 
 
 display.autoOff = false;
 console.log("Cadence Coach App Started");
+console.log("type:             " + device.type);
+console.log("model name:       " + device.modelName);
+console.log("model ID:         " + device.modelId);
+console.log("body color:       " + device.bodyColor);
+console.log("firmware version: " + device.firmwareVersion);
+console.log("last synced:      " + device.lastSyncTime);
 
 
 let targetCadenceData = document.getElementById("target-cadence-data");
@@ -16,6 +23,9 @@ let prevCadence = 0;
 let newCadence = 0;
 let weightedCadence = 0;
 let targetCadence = 180;
+
+let upper = document.getElementById("upbutton")
+let lower = document.getElementById("downbutton")
 
 targetCadenceData.text = targetCadence;
 cadenceData.text = "--";
@@ -53,15 +63,25 @@ function analyzeCadence(cadence) {
 }
 
 document.onkeypress = function(e) {
-  switch (e.key) {
-    case 'up':
-      setTargetCadence(targetCadence + 1);
-      break;
-    case 'down':
-      setTargetCadence(targetCadence - 1);
-      break;
-    default:
-      // not a key to respond to
+    switch (e.key) {
+      case 'up':
+        setTargetCadence(targetCadence + 1);
+        break;
+      case 'down':
+        setTargetCadence(targetCadence - 1);
+        break;
+      default:
+        // not a key to respond to
+    }
+}
+
+if (device.modelName == "Versa 2" || device.modelName == "Versa Lite") {
+  upper.onactivate = function(e) {
+    setTargetCadence(targetCadence + 1);
+  }
+
+  lower.onactivate = function(e) {
+    setTargetCadence(targetCadence - 1);
   }
 }
 

--- a/resources/index~300x300.gui
+++ b/resources/index~300x300.gui
@@ -1,4 +1,7 @@
 <svg>
+  <use id="upbutton" href="#push-button" y="0" height="149" />
+  <use id="downbutton" href="#push-button" y="150" height="150" />
+
   <text id="cadence-label" class="sensor-label" x="50%" y="50">cadence</text>
   <text id="cadence-data" class="sensor-data" x="50%" y="187"></text>
 

--- a/resources/widgets.gui
+++ b/resources/widgets.gui
@@ -2,5 +2,7 @@
   <defs>
     <link rel="stylesheet" href="styles.css" />
     <link rel="import" href="/mnt/sysassets/widgets_common.gui" />
+    <!-- Additional Imports -->
+    <link rel="import" href="/mnt/sysassets/widgets/push_button_widget.gui" />
   </defs>
 </svg>


### PR DESCRIPTION
This PR Fixes #2 by adding support for Versa Lite and Versa 2

Adds transparent buttons to screen of devices without physical buttons
Adds logic to take action on transparent buttons on devices without physical buttons
Adds import of push button wiget
 